### PR TITLE
Add CI Docker image publishing to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -121,3 +122,41 @@ jobs:
           name: playwright-report
           path: e2e/playwright-report/
           retention-days: 7
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: [test, e2e]
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/alecgard/octroi
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -26,7 +26,30 @@ Octroi meets agents and tools wherever they are — MCP clients talk to Octroi's
 
 ## Deploy
 
-### Quick start (local)
+### Docker (recommended)
+
+Pull the image and run with your own Postgres:
+
+```bash
+docker run -d --name octroi \
+  -e OCTROI_DATABASE_URL="postgres://octroi:SECRET@your-db:5432/octroi?sslmode=require" \
+  -e OCTROI_ENCRYPTION_KEY="$(openssl rand -hex 32)" \
+  -p 8080:8080 \
+  ghcr.io/alecgard/octroi:main
+```
+
+Octroi runs migrations automatically on startup. Log in at **http://localhost:8080/ui** with `admin@octroi.dev` / `octroi` and **change the password immediately**.
+
+Or use Docker Compose with an included Postgres:
+
+```bash
+curl -O https://raw.githubusercontent.com/alecgard/octroi/main/docker-compose.prod.yml
+OCTROI_ENCRYPTION_KEY=$(openssl rand -hex 32) docker compose -f docker-compose.prod.yml up -d
+```
+
+Images are published to `ghcr.io/alecgard/octroi` on every push to main. Pinned releases are available as `ghcr.io/alecgard/octroi:v1.0.0`.
+
+### Quick start (local development)
 
 Try Octroi on your machine — runs everything in Docker:
 
@@ -38,28 +61,6 @@ make prod-local
 Open **http://localhost:9080/ui** and log in with `admin@octroi.dev` / `octroi`.
 
 Tear down with `make clean:prod-local`.
-
-### Production (bring your own Postgres)
-
-Configure secrets in `configs/.env.prod`:
-
-```bash
-# Generate encryption key
-echo "OCTROI_ENCRYPTION_KEY=$(openssl rand -hex 32)" > configs/.env.prod
-
-# Set your Postgres connection URL
-echo "OCTROI_DATABASE_URL=postgres://octroi:STRONG_PASSWORD@your-db-host:5432/octroi?sslmode=require" >> configs/.env.prod
-```
-
-Then run the Octroi container (or binary):
-
-```bash
-docker run --env-file configs/.env.prod \
-  -v ./configs/octroi.prod.yaml:/etc/octroi.yaml \
-  octroi serve --config /etc/octroi.yaml
-```
-
-Octroi runs migrations automatically on startup. **Change the default admin password immediately** (`admin@octroi.dev` / `octroi`).
 
 ## Connect via MCP
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   octroi:
-    build: .
+    image: ghcr.io/alecgard/octroi:main
     ports:
       - "${OCTROI_PORT:-8080}:8080"
     environment:


### PR DESCRIPTION
## Summary
- New `docker` job in CI: builds and pushes to `ghcr.io/alecgard/octroi` after tests + e2e pass
- Triggers on push to main and `v*` tags
- Tags: branch name, semver, commit SHA
- GHA build cache for fast rebuilds
- Update README with Docker pull as primary deploy method
- Update docker-compose.prod.yml to use published image

Cherry-picked from `multi-tenancy` branch to unblock image publishing.

## Test plan
- [ ] Merge to main, verify CI docker job runs and image appears at ghcr.io/alecgard/octroi:main

🤖 Generated with [Claude Code](https://claude.com/claude-code)