### PR TITLE
Add Railway staging preview environments on PR

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,12 +28,10 @@ jobs:
 
       - name: Create environment (skip if exists)
         run: |
-          railway environment new $ENV_NAME \
-            --copy $SOURCE_ENV_ID \
-            --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}" \
+          railway environment new $ENV_NAME --copy $SOURCE_ENV_ID \
             || echo "Environment may already exist, continuing"
 
-      - name: Deploy to PR environment
+      - name: Deploy PR code to environment
         run: railway up -e $ENV_NAME -s $SERVICE_ID --detach
 
       - name: Comment on PR

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -31,11 +31,17 @@ jobs:
           railway environment new $ENV_NAME --copy $SOURCE_ENV_ID \
             || echo "Environment may already exist, continuing"
 
-      - name: Link to PR environment
-        run: railway link -p $PROJECT_ID -e $ENV_NAME -s $SERVICE_ID
+      - name: Find service in PR environment
+        id: svc
+        run: |
+          railway link -p $PROJECT_ID -e $ENV_NAME
+          SVC_ID=$(railway service --json | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -1)
+          echo "id=$SVC_ID" >> "$GITHUB_OUTPUT"
+          echo "Found service: $SVC_ID"
+          railway link -p $PROJECT_ID -e $ENV_NAME -s "$SVC_ID"
 
       - name: Deploy
-        run: railway up -s $SERVICE_ID --detach
+        run: railway up -s ${{ steps.svc.outputs.id }} --detach
 
       - name: Generate domain
         id: domain
@@ -58,7 +64,8 @@ jobs:
 
       - name: Seed data
         run: |
-          timeout 30 sh scripts/seed.sh ${{ steps.domain.outputs.url }} || true
+          apk add --no-cache bash curl jq
+          timeout 30 bash scripts/seed.sh ${{ steps.domain.outputs.url }} || true
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,6 +9,7 @@ env:
   PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
   SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
   SOURCE_ENV_ID: ${{ vars.RAILWAY_SOURCE_ENV_ID }}
+  SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME }}
   ENV_NAME: pr-${{ github.event.number }}
 
 jobs:
@@ -31,17 +32,11 @@ jobs:
           railway environment new $ENV_NAME --copy $SOURCE_ENV_ID \
             || echo "Environment may already exist, continuing"
 
-      - name: Find service in PR environment
-        id: svc
-        run: |
-          railway link -p $PROJECT_ID -e $ENV_NAME
-          SVC_ID=$(railway service --json | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -1)
-          echo "id=$SVC_ID" >> "$GITHUB_OUTPUT"
-          echo "Found service: $SVC_ID"
-          railway link -p $PROJECT_ID -e $ENV_NAME -s "$SVC_ID"
+      - name: Link to PR environment
+        run: railway link -p $PROJECT_ID -e $ENV_NAME -s $SERVICE_NAME
 
       - name: Deploy
-        run: railway up -s ${{ steps.svc.outputs.id }} --detach
+        run: railway up --detach
 
       - name: Generate domain
         id: domain

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Link project
+      - name: Link to base environment
         run: railway link -p $PROJECT_ID -e $SOURCE_ENV_ID -s $SERVICE_ID
 
       - name: Create environment (skip if exists)
@@ -31,13 +31,16 @@ jobs:
           railway environment new $ENV_NAME --copy $SOURCE_ENV_ID \
             || echo "Environment may already exist, continuing"
 
-      - name: Deploy PR code to environment
-        run: railway up -e $ENV_NAME -s $SERVICE_ID --detach
+      - name: Link to PR environment
+        run: railway link -p $PROJECT_ID -e $ENV_NAME -s $SERVICE_ID
+
+      - name: Deploy
+        run: railway up --detach
 
       - name: Generate domain
         id: domain
         run: |
-          DOMAIN=$(railway domain -e $ENV_NAME -s $SERVICE_ID 2>&1 || true)
+          DOMAIN=$(railway domain)
           echo "url=$DOMAIN" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
@@ -57,7 +60,7 @@ jobs:
     container: ghcr.io/railwayapp/cli:latest
 
     steps:
-      - name: Link project
+      - name: Link to base environment
         run: railway link -p $PROJECT_ID -e $SOURCE_ENV_ID -s $SERVICE_ID
 
       - name: Delete PR environment

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 env:
-  RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+  RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
   PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
   SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
   SOURCE_ENV_ID: ${{ vars.RAILWAY_SOURCE_ENV_ID }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,10 +21,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Check CLI version and link help
+      - name: Check CLI
         run: |
-          railway version
-          railway link --help
+          railway --version
+          railway --help
 
       - name: Link project
         run: railway link --project $PROJECT_ID --environment $SOURCE_ENV_ID --service $SERVICE_ID

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate domain
         id: domain
         run: |
-          DOMAIN=$(railway domain | grep -oP 'https://\S+')
+          DOMAIN=$(railway domain | sed -n 's/.*\(https:\/\/[^ ]*\).*/\1/p')
           echo "url=$DOMAIN" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,11 +21,8 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Debug auth
-        run: |
-          railway --version
-          railway whoami
-          railway link --help 2>&1 || true
+      - name: Link project
+        run: railway link -p $PROJECT_ID -e $SOURCE_ENV_ID -s $SERVICE_ID
 
       - name: Create environment (skip if exists)
         run: |
@@ -55,7 +52,7 @@ jobs:
 
     steps:
       - name: Link project
-        run: railway link --project $PROJECT_ID --environment $SOURCE_ENV_ID --service $SERVICE_ID
+        run: railway link -p $PROJECT_ID -e $SOURCE_ENV_ID -s $SERVICE_ID
 
       - name: Delete PR environment
         run: railway environment delete $ENV_NAME --yes || true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -43,6 +43,26 @@ jobs:
           DOMAIN=$(railway domain | sed -n 's/.*\(https:\/\/[^ ]*\).*/\1/p')
           echo "url=$DOMAIN" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for deploy to be live
+        run: |
+          for i in $(seq 1 30); do
+            if wget -q --spider "${{ steps.domain.outputs.url }}/health" 2>/dev/null; then
+              echo "App is live"
+              exit 0
+            fi
+            echo "Waiting for deploy... ($i/30)"
+            sleep 10
+          done
+          echo "Timed out waiting for deploy"
+          exit 1
+
+      - name: Create admin user
+        run: railway run -s $SERVICE_ID -- octroi ensure-admin --config /dev/null
+
+      - name: Seed data
+        run: |
+          timeout 30 sh scripts/seed.sh ${{ steps.domain.outputs.url }} || true
+
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -35,7 +35,7 @@ jobs:
         run: railway link -p $PROJECT_ID -e $ENV_NAME -s $SERVICE_ID
 
       - name: Deploy
-        run: railway up --detach
+        run: railway up -s $SERVICE_ID --detach
 
       - name: Generate domain
         id: domain
@@ -50,7 +50,7 @@ jobs:
           message: |
             **Staging deployed** :rocket:
 
-            https://${{ steps.domain.outputs.url }}/ui
+            ${{ steps.domain.outputs.url }}/ui
 
             Login: `admin@octroi.dev` / `octroi`
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -56,9 +56,6 @@ jobs:
           echo "Timed out waiting for deploy"
           exit 1
 
-      - name: Create admin user
-        run: railway run -s $SERVICE_ID -- octroi ensure-admin --config /dev/null
-
       - name: Seed data
         run: |
           timeout 30 sh scripts/seed.sh ${{ steps.domain.outputs.url }} || true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,8 +21,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Check CLI version and link help
+        run: |
+          railway version
+          railway link --help
+
       - name: Link project
-        run: railway link $PROJECT_ID $SOURCE_ENV_ID $SERVICE_ID
+        run: railway link --project $PROJECT_ID --environment $SOURCE_ENV_ID --service $SERVICE_ID
 
       - name: Create environment (skip if exists)
         run: |
@@ -31,11 +36,8 @@ jobs:
             --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}" \
             || echo "Environment may already exist, continuing"
 
-      - name: Switch to PR environment
-        run: railway link $PROJECT_ID $ENV_NAME $SERVICE_ID
-
-      - name: Deploy
-        run: railway up --detach
+      - name: Deploy to PR environment
+        run: railway up -e $ENV_NAME -s $SERVICE_ID --detach
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
@@ -55,7 +57,7 @@ jobs:
 
     steps:
       - name: Link project
-        run: railway link $PROJECT_ID $SOURCE_ENV_ID $SERVICE_ID
+        run: railway link --project $PROJECT_ID --environment $SOURCE_ENV_ID --service $SERVICE_ID
 
       - name: Delete PR environment
         run: railway environment delete $ENV_NAME --yes || true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,10 +5,10 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 env:
-  RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-  RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-  RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
-  RAILWAY_SOURCE_ENV_ID: ${{ vars.RAILWAY_SOURCE_ENV_ID }}
+  RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+  PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+  SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+  SOURCE_ENV_ID: ${{ vars.RAILWAY_SOURCE_ENV_ID }}
 
 jobs:
   deploy:
@@ -20,28 +20,15 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Link to project
-        run: railway link --project $RAILWAY_PROJECT_ID --environment $RAILWAY_SOURCE_ENV_ID
-
       - name: Create or update environment
         run: |
-          railway environment new pr-${{ github.event.number }} \
-            --copy $RAILWAY_SOURCE_ENV_ID \
-            --service-config $RAILWAY_SERVICE_ID "source.branch" "${{ github.head_ref }}" \
+          railway environment --project $PROJECT_ID new pr-${{ github.event.number }} \
+            --copy $SOURCE_ENV_ID \
+            --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}" \
             2>/dev/null || true
-          railway environment use pr-${{ github.event.number }}
 
-      - name: Trigger deploy
-        run: railway up --service $RAILWAY_SERVICE_ID --detach
-
-      - name: Get deployment URL
-        id: url
-        run: |
-          DOMAIN=$(railway domain --json 2>/dev/null | jq -r '.[0]' || echo "")
-          if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
-            DOMAIN="pr-${{ github.event.number }}-octroi.up.railway.app"
-          fi
-          echo "url=https://$DOMAIN" >> "$GITHUB_OUTPUT"
+      - name: Deploy
+        run: railway up --project $PROJECT_ID --environment pr-${{ github.event.number }} --service $SERVICE_ID --detach
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
@@ -50,7 +37,7 @@ jobs:
           message: |
             **Staging deployed** :rocket:
 
-            ${{ steps.url.outputs.url }}/ui
+            https://pr-${{ github.event.number }}-octroi.up.railway.app/ui
 
             Login: `admin@octroi.dev` / `octroi`
 
@@ -60,8 +47,5 @@ jobs:
     container: ghcr.io/railwayapp/cli:latest
 
     steps:
-      - name: Link to project
-        run: railway link --project $RAILWAY_PROJECT_ID --environment $RAILWAY_SOURCE_ENV_ID
-
       - name: Delete PR environment
-        run: railway environment delete pr-${{ github.event.number }} --yes || true
+        run: railway environment --project $PROJECT_ID delete pr-${{ github.event.number }} --yes || true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,13 +21,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Check CLI
+      - name: Debug auth
         run: |
           railway --version
-          railway --help
-
-      - name: Link project
-        run: railway link --project $PROJECT_ID --environment $SOURCE_ENV_ID --service $SERVICE_ID
+          railway whoami
+          railway link --help 2>&1 || true
 
       - name: Create environment (skip if exists)
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,6 +21,8 @@ jobs:
       pull-requests: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Link project
         run: railway link -p $PROJECT_ID -e $SOURCE_ENV_ID -s $SERVICE_ID
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,6 +9,7 @@ env:
   PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
   SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
   SOURCE_ENV_ID: ${{ vars.RAILWAY_SOURCE_ENV_ID }}
+  ENV_NAME: pr-${{ github.event.number }}
 
 jobs:
   deploy:
@@ -20,14 +21,21 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Create environment
+      - name: Link project
+        run: railway link $PROJECT_ID $SOURCE_ENV_ID $SERVICE_ID
+
+      - name: Create environment (skip if exists)
         run: |
-          railway environment --project $PROJECT_ID new pr-${{ github.event.number }} \
+          railway environment new $ENV_NAME \
             --copy $SOURCE_ENV_ID \
-            --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}"
+            --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}" \
+            || echo "Environment may already exist, continuing"
+
+      - name: Switch to PR environment
+        run: railway link $PROJECT_ID $ENV_NAME $SERVICE_ID
 
       - name: Deploy
-        run: railway up --project $PROJECT_ID --environment pr-${{ github.event.number }} --service $SERVICE_ID --detach
+        run: railway up --detach
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
@@ -36,7 +44,7 @@ jobs:
           message: |
             **Staging deployed** :rocket:
 
-            https://pr-${{ github.event.number }}-octroi.up.railway.app/ui
+            https://${{ env.ENV_NAME }}-octroi.up.railway.app/ui
 
             Login: `admin@octroi.dev` / `octroi`
 
@@ -46,5 +54,8 @@ jobs:
     container: ghcr.io/railwayapp/cli:latest
 
     steps:
+      - name: Link project
+        run: railway link $PROJECT_ID $SOURCE_ENV_ID $SERVICE_ID
+
       - name: Delete PR environment
-        run: railway environment --project $PROJECT_ID delete pr-${{ github.event.number }} --yes || true
+        run: railway environment delete $ENV_NAME --yes || true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,3 +1,22 @@
+# Deploys each PR to a dedicated Railway environment with its own Postgres.
+# Auto-creates on PR open/push, destroys on close/merge.
+#
+# Required GitHub secrets:
+#   RAILWAY_API_TOKEN       - Account token from https://railway.com/account/tokens
+#
+# Required GitHub variables (Settings > Secrets and variables > Actions > Variables):
+#   RAILWAY_PROJECT_ID      - Railway project UUID (from dashboard URL)
+#   RAILWAY_SERVICE_ID      - Octroi service UUID in the base environment
+#   RAILWAY_SOURCE_ENV_ID   - Base environment UUID to copy from
+#   RAILWAY_SERVICE_NAME    - Octroi service name (e.g. "octroi")
+#
+# Railway project setup:
+#   1. Create project with Octroi service (Docker image: ghcr.io/alecgard/octroi:latest)
+#   2. Add Postgres database
+#   3. Set service variables: OCTROI_DATABASE_URL=${{Postgres.DATABASE_URL}},
+#      OCTROI_ENCRYPTION_KEY, OCTROI_HOST=0.0.0.0, OCTROI_PORT=8080
+#   4. Enable private networking (RAILWAY_ENABLE_PRIVATE_NETWORKING=true)
+
 name: Staging
 
 on:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate domain
         id: domain
         run: |
-          DOMAIN=$(railway domain)
+          DOMAIN=$(railway domain | grep -oP 'https://\S+')
           echo "url=$DOMAIN" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,67 @@
+name: Staging
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+env:
+  RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+  RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+  RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+  RAILWAY_SOURCE_ENV_ID: ${{ vars.RAILWAY_SOURCE_ENV_ID }}
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Link to project
+        run: railway link --project $RAILWAY_PROJECT_ID --environment $RAILWAY_SOURCE_ENV_ID
+
+      - name: Create or update environment
+        run: |
+          railway environment new pr-${{ github.event.number }} \
+            --copy $RAILWAY_SOURCE_ENV_ID \
+            --service-config $RAILWAY_SERVICE_ID "source.branch" "${{ github.head_ref }}" \
+            2>/dev/null || true
+          railway environment use pr-${{ github.event.number }}
+
+      - name: Trigger deploy
+        run: railway up --service $RAILWAY_SERVICE_ID --detach
+
+      - name: Get deployment URL
+        id: url
+        run: |
+          DOMAIN=$(railway domain --json 2>/dev/null | jq -r '.[0]' || echo "")
+          if [ -z "$DOMAIN" ] || [ "$DOMAIN" = "null" ]; then
+            DOMAIN="pr-${{ github.event.number }}-octroi.up.railway.app"
+          fi
+          echo "url=https://$DOMAIN" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: staging
+          message: |
+            **Staging deployed** :rocket:
+
+            ${{ steps.url.outputs.url }}/ui
+
+            Login: `admin@octroi.dev` / `octroi`
+
+  destroy:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    container: ghcr.io/railwayapp/cli:latest
+
+    steps:
+      - name: Link to project
+        run: railway link --project $RAILWAY_PROJECT_ID --environment $RAILWAY_SOURCE_ENV_ID
+
+      - name: Delete PR environment
+        run: railway environment delete pr-${{ github.event.number }} --yes || true

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Deploy PR code to environment
         run: railway up -e $ENV_NAME -s $SERVICE_ID --detach
 
+      - name: Generate domain
+        id: domain
+        run: |
+          DOMAIN=$(railway domain -e $ENV_NAME -s $SERVICE_ID 2>&1 || true)
+          echo "url=$DOMAIN" >> "$GITHUB_OUTPUT"
+
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:
@@ -41,7 +47,7 @@ jobs:
           message: |
             **Staging deployed** :rocket:
 
-            https://${{ env.ENV_NAME }}-octroi.up.railway.app/ui
+            https://${{ steps.domain.outputs.url }}/ui
 
             Login: `admin@octroi.dev` / `octroi`
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -20,12 +20,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Create or update environment
+      - name: Create environment
         run: |
           railway environment --project $PROJECT_ID new pr-${{ github.event.number }} \
             --copy $SOURCE_ENV_ID \
-            --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}" \
-            2>/dev/null || true
+            --service-config $SERVICE_ID "source.branch" "${{ github.head_ref }}"
 
       - name: Deploy
         run: railway up --project $PROJECT_ID --environment pr-${{ github.event.number }} --service $SERVICE_ID --detach

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY --from=builder /octroi /usr/local/bin/octroi
 COPY migrations/ /migrations/
 EXPOSE 8080
 ENTRYPOINT ["sh", "-c"]
-CMD ["octroi migrate --config /dev/null && octroi serve --config /dev/null"]
+CMD ["octroi migrate --config /dev/null && octroi ensure-admin --config /dev/null && octroi serve --config /dev/null"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ RUN apk --no-cache add ca-certificates
 COPY --from=builder /octroi /usr/local/bin/octroi
 COPY migrations/ /migrations/
 EXPOSE 8080
-ENTRYPOINT ["octroi"]
-CMD ["serve"]
+ENTRYPOINT ["sh", "-c"]
+CMD ["octroi migrate --config /dev/null && octroi serve --config /dev/null"]


### PR DESCRIPTION
## Summary
- New `staging.yml` workflow: deploys each PR to a dedicated Railway environment with its own Postgres
- Auto-creates on PR open, rebuilds on push, destroys on close/merge
- Runs migrations and ensure-admin in Dockerfile entrypoint
- Seeds data via `scripts/seed.sh` after deploy is healthy
- Posts sticky PR comment with staging URL and login credentials

## Setup

### GitHub Secrets
| Name | Description |
|------|-------------|
| `RAILWAY_API_TOKEN` | Account token from https://railway.com/account/tokens |

### GitHub Variables
| Name | Description |
|------|-------------|
| `RAILWAY_PROJECT_ID` | Railway project UUID (from dashboard URL) |
| `RAILWAY_SERVICE_ID` | Octroi service UUID in the base environment |
| `RAILWAY_SOURCE_ENV_ID` | Base environment UUID to copy from |
| `RAILWAY_SERVICE_NAME` | Octroi service name (e.g. `octroi`) |

### Railway project
1. Create project with Octroi service (`ghcr.io/alecgard/octroi:latest`)
2. Add Postgres database
3. Set service variables: `OCTROI_DATABASE_URL=${{Postgres.DATABASE_URL}}`, `OCTROI_ENCRYPTION_KEY`, `OCTROI_HOST=0.0.0.0`, `OCTROI_PORT=8080`
4. Enable private networking (`RAILWAY_ENABLE_PRIVATE_NETWORKING=true`)

## Test plan
- [x] PR open triggers deploy, staging URL is accessible
- [x] Admin login works (`admin@octroi.dev` / `octroi`)
- [x] Seed data populates tools, agents, teams
- [ ] PR close destroys the Railway environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)