### PR TITLE
Fix usage chart to end at now in live mode

### DIFF
--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -3287,6 +3287,13 @@ function renderUsageChart(txns) {
     svg += `<text x="${x}" y="${H - MB + 14}" text-anchor="middle" class="chart-label">${fmtBucketLabel(d, bucketMs)}</text>`;
   }
 
+  // In live mode, draw a "Now" marker at the right edge of the chart.
+  if (usageMode === 'live') {
+    const nowX = ML + ((now - bucketStart) / (bucketEnd - bucketStart)) * chartW;
+    svg += `<line x1="${nowX}" y1="${MT}" x2="${nowX}" y2="${MT + chartH}" stroke="var(--text2)" stroke-width="1" stroke-dasharray="3,3" opacity="0.5"/>`;
+    svg += `<text x="${nowX}" y="${H - MB + 14}" text-anchor="middle" class="chart-label" style="font-weight:600">Now</text>`;
+  }
+
   svg += '</svg>';
 
   // Legend


### PR DESCRIPTION
## Summary
- When the usage chart is in live mode, extend the x-axis to the current time instead of stopping at the last data point
- Add a dashed vertical "Now" marker line and label on the x-axis to visually indicate the current time

Closes #12

## Test plan
- [ ] Open usage dashboard in live mode
- [ ] Verify chart x-axis extends to current time with a "Now" marker
- [ ] Verify non-live mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)