### PR TITLE
Fix login rate limit IP extraction and increase limit

### DIFF
--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -78,9 +79,24 @@ func auditLog(r *http.Request, action string, resourceType string, resourceID st
 	}
 }
 
+// clientIP extracts the client IP address from the request.
+// It checks X-Forwarded-For first (taking the leftmost/first IP),
+// then X-Real-IP, and falls back to RemoteAddr.
 func clientIP(r *http.Request) string {
 	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		return fwd
+		return parseForwardedFor(fwd)
+	}
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		return strings.TrimSpace(realIP)
 	}
 	return r.RemoteAddr
+}
+
+// parseForwardedFor extracts the first (leftmost/client) IP from an
+// X-Forwarded-For header value, which may contain a comma-separated list.
+func parseForwardedFor(fwd string) string {
+	if i := strings.IndexByte(fwd, ','); i > 0 {
+		return strings.TrimSpace(fwd[:i])
+	}
+	return strings.TrimSpace(fwd)
 }

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		want       string
+	}{
+		{
+			name:       "remote addr only",
+			remoteAddr: "192.168.1.1:12345",
+			want:       "192.168.1.1:12345",
+		},
+		{
+			name:       "single X-Forwarded-For",
+			remoteAddr: "10.0.0.1:12345",
+			headers:    map[string]string{"X-Forwarded-For": "203.0.113.50"},
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "multiple X-Forwarded-For takes first",
+			remoteAddr: "10.0.0.1:12345",
+			headers:    map[string]string{"X-Forwarded-For": "203.0.113.50, 70.41.3.18, 150.172.238.178"},
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "X-Forwarded-For with spaces",
+			remoteAddr: "10.0.0.1:12345",
+			headers:    map[string]string{"X-Forwarded-For": "  203.0.113.50 , 70.41.3.18 "},
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "X-Real-IP fallback",
+			remoteAddr: "10.0.0.1:12345",
+			headers:    map[string]string{"X-Real-IP": "203.0.113.50"},
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "X-Real-IP with whitespace",
+			remoteAddr: "10.0.0.1:12345",
+			headers:    map[string]string{"X-Real-IP": "  203.0.113.50  "},
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "X-Forwarded-For takes precedence over X-Real-IP",
+			remoteAddr: "10.0.0.1:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "203.0.113.50",
+				"X-Real-IP":       "198.51.100.10",
+			},
+			want: "203.0.113.50",
+		},
+		{
+			name:       "empty X-Forwarded-For falls through to X-Real-IP",
+			remoteAddr: "10.0.0.1:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "",
+				"X-Real-IP":       "198.51.100.10",
+			},
+			want: "198.51.100.10",
+		},
+		{
+			name:       "empty headers fall through to RemoteAddr",
+			remoteAddr: "10.0.0.1:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "",
+				"X-Real-IP":       "",
+			},
+			want: "10.0.0.1:12345",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			r.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				if v != "" {
+					r.Header.Set(k, v)
+				}
+			}
+			got := clientIP(r)
+			if got != tt.want {
+				t.Errorf("clientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseForwardedFor(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"203.0.113.50", "203.0.113.50"},
+		{"203.0.113.50, 70.41.3.18", "203.0.113.50"},
+		{"203.0.113.50, 70.41.3.18, 150.172.238.178", "203.0.113.50"},
+		{"  203.0.113.50  ", "203.0.113.50"},
+		{"  203.0.113.50 , 70.41.3.18 ", "203.0.113.50"},
+		{"2001:db8::1, 203.0.113.50", "2001:db8::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseForwardedFor(tt.input)
+			if got != tt.want {
+				t.Errorf("parseForwardedFor(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -159,8 +159,8 @@ func NewRouter(deps RouterDeps) http.Handler {
 		usage.setBodyStore(deps.BodyStore)
 	}
 
-	// Login rate limiter: 5 attempts per IP per minute.
-	loginRL := newLoginRateLimiter(5, time.Minute)
+	// Login rate limiter: 10 attempts per IP per minute.
+	loginRL := newLoginRateLimiter(10, time.Minute)
 	loginRL.startCleanup(context.Background(), 5*time.Minute)
 
 	// Session lookup adapter for user auth middlewares.
@@ -224,10 +224,7 @@ func NewRouter(deps RouterDeps) http.Handler {
 	if deps.UserStore != nil {
 		authH := newAuthHandler(deps.UserStore)
 		r.Post("/api/v1/auth/login", func(w http.ResponseWriter, r *http.Request) {
-			ip := r.RemoteAddr
-			if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-				ip = fwd
-			}
+			ip := clientIP(r)
 			allowed, retryAfter := loginRL.allow(ip)
 			if !allowed {
 				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))


### PR DESCRIPTION
## Summary
- Fix X-Forwarded-For parsing to extract the leftmost client IP instead of using the full header value as the rate limit key
- Add X-Real-IP fallback for proxies that use it
- Increase login rate limit from 5/min to 10/min per IP to avoid affecting legitimate users
- Share IP extraction logic between rate limiting and audit logging

Closes #8

## Test plan
- [ ] Unit tests for IP extraction with various header formats
- [ ] Verify rate limiting works correctly per-client behind proxy
- [ ] Verify audit logs show correct client IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)