### PR TITLE
Add API key rotation with grace period

### DIFF
--- a/e2e/tests/agents.spec.ts
+++ b/e2e/tests/agents.spec.ts
@@ -65,10 +65,13 @@ test.describe('Agents tab', () => {
       // Submit.
       await page.locator('#agent-submit-btn').click();
 
-      // Verify the API key banner appears with an octroi_ prefixed key.
-      await expect(page.locator('#agent-key-banner')).toHaveClass(/show/);
-      const keyValue = await page.locator('#agent-key-value').innerText();
+      // Verify the API key modal appears with an octroi_ prefixed key.
+      await expect(page.locator('#confirm-modal')).toHaveClass(/open/);
+      const keyValue = await page.locator('#confirm-msg code').innerText();
       expect(keyValue).toMatch(/^octroi_/);
+
+      // Dismiss the key modal.
+      await page.locator('#confirm-ok').click();
 
       // Navigate back to agents tab to find the row.
       await page.goto('/ui#agents');

--- a/internal/agent/auth_adapter.go
+++ b/internal/agent/auth_adapter.go
@@ -17,15 +17,25 @@ func NewAuthAdapter(store *Store) *AuthAdapter {
 }
 
 // GetByKeyHash looks up an agent by API key hash and converts to auth.Agent.
+// It checks the active key first, then falls back to the previous (expiring) key.
 func (a *AuthAdapter) GetByKeyHash(ctx context.Context, hash string) (*auth.Agent, error) {
 	ag, err := a.store.GetByKeyHash(ctx, hash)
 	if err != nil {
-		return nil, err
+		// Primary key not found; try the previous (expiring) key.
+		ag, prevErr := a.store.GetByPrevKeyHash(ctx, hash)
+		if prevErr != nil {
+			return nil, err // return original error
+		}
+		return agentToAuth(ag), nil
 	}
+	return agentToAuth(ag), nil
+}
+
+func agentToAuth(ag *Agent) *auth.Agent {
 	return &auth.Agent{
 		ID:        ag.ID,
 		Name:      ag.Name,
 		Team:      ag.Team,
 		RateLimit: ag.RateLimit,
-	}, nil
+	}
 }

--- a/internal/agent/models.go
+++ b/internal/agent/models.go
@@ -8,12 +8,14 @@ type Agent struct {
 	Name             string     `json:"name"`
 	APIKeyHash       string     `json:"-"`
 	APIKeyPrefix     string     `json:"api_key_prefix"`
+	APIKeySuffix     string     `json:"api_key_suffix"`
 	Team             string     `json:"team"`
 	RateLimit        int        `json:"rate_limit"`
 	AllowlistMode    bool       `json:"allowlist_mode"`
 	CreatedAt        time.Time  `json:"created_at"`
 	ArchivedAt       *time.Time `json:"archived_at,omitempty"`
 	PrevKeyHash      *string    `json:"-"`
+	PrevKeyPrefix    *string    `json:"prev_key_prefix,omitempty"`
 	PrevKeyExpiresAt *time.Time `json:"prev_key_expires_at,omitempty"`
 }
 
@@ -22,6 +24,7 @@ type CreateAgentInput struct {
 	Name         string `json:"name"`
 	APIKeyHash   string `json:"api_key_hash"`
 	APIKeyPrefix string `json:"api_key_prefix"`
+	APIKeySuffix string `json:"api_key_suffix"`
 	Team         string `json:"team"`
 	RateLimit    int    `json:"rate_limit"`
 }

--- a/internal/agent/models.go
+++ b/internal/agent/models.go
@@ -4,15 +4,17 @@ import "time"
 
 // Agent represents a registered API agent.
 type Agent struct {
-	ID            string    `json:"id"`
-	Name          string    `json:"name"`
-	APIKeyHash    string    `json:"-"`
-	APIKeyPrefix  string    `json:"api_key_prefix"`
-	Team          string    `json:"team"`
-	RateLimit     int       `json:"rate_limit"`
-	AllowlistMode bool       `json:"allowlist_mode"`
-	CreatedAt     time.Time  `json:"created_at"`
-	ArchivedAt    *time.Time `json:"archived_at,omitempty"`
+	ID               string     `json:"id"`
+	Name             string     `json:"name"`
+	APIKeyHash       string     `json:"-"`
+	APIKeyPrefix     string     `json:"api_key_prefix"`
+	Team             string     `json:"team"`
+	RateLimit        int        `json:"rate_limit"`
+	AllowlistMode    bool       `json:"allowlist_mode"`
+	CreatedAt        time.Time  `json:"created_at"`
+	ArchivedAt       *time.Time `json:"archived_at,omitempty"`
+	PrevKeyHash      *string    `json:"-"`
+	PrevKeyExpiresAt *time.Time `json:"prev_key_expires_at,omitempty"`
 }
 
 // CreateAgentInput holds the fields required to create a new agent.

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -11,6 +11,29 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// agentColumns is the standard column list for agent queries.
+const agentColumns = `id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at, prev_key_hash, prev_key_expires_at`
+
+// scanAgent scans a row into an Agent struct using the standard column order.
+func scanAgent(row pgx.Row) (*Agent, error) {
+	a := &Agent{}
+	err := row.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt, &a.PrevKeyHash, &a.PrevKeyExpiresAt)
+	return a, err
+}
+
+// scanAgentRows scans multiple rows into Agent structs.
+func scanAgentRows(rows pgx.Rows) ([]*Agent, error) {
+	var agents []*Agent
+	for rows.Next() {
+		a := &Agent{}
+		if err := rows.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt, &a.PrevKeyHash, &a.PrevKeyExpiresAt); err != nil {
+			return nil, err
+		}
+		agents = append(agents, a)
+	}
+	return agents, rows.Err()
+}
+
 // Store provides database operations for agents.
 type Store struct {
 	pool *pgxpool.Pool
@@ -23,13 +46,12 @@ func NewStore(pool *pgxpool.Pool) *Store {
 
 // Create inserts a new agent and returns the created record.
 func (s *Store) Create(ctx context.Context, in CreateAgentInput) (*Agent, error) {
-	a := &Agent{}
-	err := s.pool.QueryRow(ctx,
+	a, err := scanAgent(s.pool.QueryRow(ctx,
 		`INSERT INTO agents (name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode)
 		 VALUES ($1, $2, $3, $4, $5, $6)
-		 RETURNING id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at`,
+		 RETURNING `+agentColumns,
 		in.Name, in.APIKeyHash, in.APIKeyPrefix, in.Team, in.RateLimit, false,
-	).Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt)
+	))
 	if err != nil {
 		return nil, fmt.Errorf("creating agent: %w", err)
 	}
@@ -38,29 +60,38 @@ func (s *Store) Create(ctx context.Context, in CreateAgentInput) (*Agent, error)
 
 // GetByID retrieves an active (non-archived) agent by its primary key.
 func (s *Store) GetByID(ctx context.Context, id string) (*Agent, error) {
-	a := &Agent{}
-	err := s.pool.QueryRow(ctx,
-		`SELECT id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at
-		 FROM agents WHERE id = $1 AND archived_at IS NULL`,
-		id,
-	).Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt)
+	a, err := scanAgent(s.pool.QueryRow(ctx,
+		`SELECT `+agentColumns+` FROM agents WHERE id = $1 AND archived_at IS NULL`, id,
+	))
 	if err != nil {
 		return nil, fmt.Errorf("getting agent by id: %w", err)
 	}
 	return a, nil
 }
 
-
-// GetByKeyHash retrieves an agent by its API key hash, used for authentication.
+// GetByKeyHash retrieves an agent by its current API key hash, used for authentication.
 func (s *Store) GetByKeyHash(ctx context.Context, hash string) (*Agent, error) {
-	a := &Agent{}
-	err := s.pool.QueryRow(ctx,
-		`SELECT id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at
-		 FROM agents WHERE api_key_hash = $1 AND archived_at IS NULL`,
-		hash,
-	).Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt)
+	a, err := scanAgent(s.pool.QueryRow(ctx,
+		`SELECT `+agentColumns+` FROM agents WHERE api_key_hash = $1 AND archived_at IS NULL`, hash,
+	))
 	if err != nil {
 		return nil, fmt.Errorf("getting agent by key hash: %w", err)
+	}
+	return a, nil
+}
+
+// GetByPrevKeyHash retrieves an agent by its previous (expiring) key hash.
+// Returns the agent only if the previous key has not yet expired.
+func (s *Store) GetByPrevKeyHash(ctx context.Context, hash string) (*Agent, error) {
+	a, err := scanAgent(s.pool.QueryRow(ctx,
+		`SELECT `+agentColumns+`
+		 FROM agents
+		 WHERE prev_key_hash = $1 AND archived_at IS NULL
+		   AND prev_key_expires_at IS NOT NULL AND prev_key_expires_at > now()`,
+		hash,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("getting agent by prev key hash: %w", err)
 	}
 	return a, nil
 }
@@ -83,7 +114,7 @@ func (s *Store) List(ctx context.Context, params AgentListParams) ([]*Agent, str
 			return nil, "", fmt.Errorf("invalid cursor: %w", cerr)
 		}
 		rows, err = s.pool.Query(ctx,
-			`SELECT id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at
+			`SELECT `+agentColumns+`
 			 FROM agents
 			 WHERE archived_at IS NULL AND (created_at, id) < ($1, $2)
 			 ORDER BY created_at DESC, id DESC
@@ -92,7 +123,7 @@ func (s *Store) List(ctx context.Context, params AgentListParams) ([]*Agent, str
 		)
 	} else {
 		rows, err = s.pool.Query(ctx,
-			`SELECT id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at
+			`SELECT `+agentColumns+`
 			 FROM agents
 			 WHERE archived_at IS NULL
 			 ORDER BY created_at DESC, id DESC
@@ -105,16 +136,9 @@ func (s *Store) List(ctx context.Context, params AgentListParams) ([]*Agent, str
 	}
 	defer rows.Close()
 
-	var agents []*Agent
-	for rows.Next() {
-		a := &Agent{}
-		if err := rows.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt); err != nil {
-			return nil, "", fmt.Errorf("scanning agent row: %w", err)
-		}
-		agents = append(agents, a)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("iterating agent rows: %w", err)
+	agents, err := scanAgentRows(rows)
+	if err != nil {
+		return nil, "", fmt.Errorf("scanning agent rows: %w", err)
 	}
 
 	var nextCursor string
@@ -144,7 +168,7 @@ func (s *Store) ListByTeams(ctx context.Context, teams []string, params AgentLis
 			return nil, "", fmt.Errorf("invalid cursor: %w", cerr)
 		}
 		rows, err = s.pool.Query(ctx,
-			`SELECT id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at
+			`SELECT `+agentColumns+`
 			 FROM agents
 			 WHERE team = ANY($1) AND archived_at IS NULL AND (created_at, id) < ($2, $3)
 			 ORDER BY created_at DESC, id DESC
@@ -153,7 +177,7 @@ func (s *Store) ListByTeams(ctx context.Context, teams []string, params AgentLis
 		)
 	} else {
 		rows, err = s.pool.Query(ctx,
-			`SELECT id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at
+			`SELECT `+agentColumns+`
 			 FROM agents
 			 WHERE team = ANY($1) AND archived_at IS NULL
 			 ORDER BY created_at DESC, id DESC
@@ -166,16 +190,9 @@ func (s *Store) ListByTeams(ctx context.Context, teams []string, params AgentLis
 	}
 	defer rows.Close()
 
-	var agents []*Agent
-	for rows.Next() {
-		a := &Agent{}
-		if err := rows.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt); err != nil {
-			return nil, "", fmt.Errorf("scanning agent row: %w", err)
-		}
-		agents = append(agents, a)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, "", fmt.Errorf("iterating agent rows: %w", err)
+	agents, err := scanAgentRows(rows)
+	if err != nil {
+		return nil, "", fmt.Errorf("scanning agent rows: %w", err)
 	}
 
 	var nextCursor string
@@ -212,18 +229,59 @@ func (s *Store) ListIDsByTeams(ctx context.Context, teams []string) ([]string, e
 	return ids, rows.Err()
 }
 
-// RegenerateKey updates the api_key_hash and api_key_prefix for the given agent.
-func (s *Store) RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*Agent, error) {
-	a := &Agent{}
-	err := s.pool.QueryRow(ctx,
-		`UPDATE agents SET api_key_hash = $1, api_key_prefix = $2 WHERE id = $3
-		 RETURNING id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at`,
+// RotateKey moves the current key to prev_key with a 24h grace period and sets
+// the new key as the active key.
+func (s *Store) RotateKey(ctx context.Context, id, newHash, newPrefix string) (*Agent, error) {
+	a, err := scanAgent(s.pool.QueryRow(ctx,
+		`UPDATE agents
+		 SET prev_key_hash = api_key_hash,
+		     prev_key_expires_at = now() + interval '24 hours',
+		     api_key_hash = $1,
+		     api_key_prefix = $2
+		 WHERE id = $3 AND archived_at IS NULL
+		 RETURNING `+agentColumns,
 		newHash, newPrefix, id,
-	).Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt)
+	))
 	if err != nil {
-		return nil, fmt.Errorf("regenerating agent key: %w", err)
+		return nil, fmt.Errorf("rotating agent key: %w", err)
 	}
 	return a, nil
+}
+
+// RevokePrevKey immediately clears the previous key for the given agent.
+func (s *Store) RevokePrevKey(ctx context.Context, id string) (*Agent, error) {
+	a, err := scanAgent(s.pool.QueryRow(ctx,
+		`UPDATE agents
+		 SET prev_key_hash = NULL,
+		     prev_key_expires_at = NULL
+		 WHERE id = $1 AND archived_at IS NULL
+		 RETURNING `+agentColumns,
+		id,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("revoking prev key: %w", err)
+	}
+	return a, nil
+}
+
+// CleanupExpiredKeys clears prev_key_hash and prev_key_expires_at for all
+// agents whose previous key has expired.
+func (s *Store) CleanupExpiredKeys(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE agents
+		 SET prev_key_hash = NULL, prev_key_expires_at = NULL
+		 WHERE prev_key_expires_at IS NOT NULL AND prev_key_expires_at <= now()`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("cleaning up expired keys: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// RegenerateKey updates the api_key_hash and api_key_prefix for the given agent.
+// Deprecated: Use RotateKey for zero-downtime rotation with a grace period.
+func (s *Store) RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*Agent, error) {
+	return s.RotateKey(ctx, id, newHash, newPrefix)
 }
 
 // Update performs a partial update on the agent with the given id and returns
@@ -261,13 +319,11 @@ func (s *Store) Update(ctx context.Context, id string, in UpdateAgentInput) (*Ag
 	args = append(args, id)
 	query := fmt.Sprintf(
 		`UPDATE agents SET %s WHERE id = $%d
-		 RETURNING id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at`,
+		 RETURNING `+agentColumns,
 		strings.Join(setClauses, ", "), argIdx,
 	)
 
-	a := &Agent{}
-	err := s.pool.QueryRow(ctx, query, args...).
-		Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt)
+	a, err := scanAgent(s.pool.QueryRow(ctx, query, args...))
 	if err != nil {
 		return nil, fmt.Errorf("updating agent: %w", err)
 	}

--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -12,12 +12,12 @@ import (
 )
 
 // agentColumns is the standard column list for agent queries.
-const agentColumns = `id, name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode, created_at, prev_key_hash, prev_key_expires_at`
+const agentColumns = `id, name, api_key_hash, api_key_prefix, api_key_suffix, team, rate_limit, allowlist_mode, created_at, prev_key_hash, prev_key_prefix, prev_key_expires_at`
 
 // scanAgent scans a row into an Agent struct using the standard column order.
 func scanAgent(row pgx.Row) (*Agent, error) {
 	a := &Agent{}
-	err := row.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt, &a.PrevKeyHash, &a.PrevKeyExpiresAt)
+	err := row.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.APIKeySuffix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt, &a.PrevKeyHash, &a.PrevKeyPrefix, &a.PrevKeyExpiresAt)
 	return a, err
 }
 
@@ -26,7 +26,7 @@ func scanAgentRows(rows pgx.Rows) ([]*Agent, error) {
 	var agents []*Agent
 	for rows.Next() {
 		a := &Agent{}
-		if err := rows.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt, &a.PrevKeyHash, &a.PrevKeyExpiresAt); err != nil {
+		if err := rows.Scan(&a.ID, &a.Name, &a.APIKeyHash, &a.APIKeyPrefix, &a.APIKeySuffix, &a.Team, &a.RateLimit, &a.AllowlistMode, &a.CreatedAt, &a.PrevKeyHash, &a.PrevKeyPrefix, &a.PrevKeyExpiresAt); err != nil {
 			return nil, err
 		}
 		agents = append(agents, a)
@@ -47,10 +47,10 @@ func NewStore(pool *pgxpool.Pool) *Store {
 // Create inserts a new agent and returns the created record.
 func (s *Store) Create(ctx context.Context, in CreateAgentInput) (*Agent, error) {
 	a, err := scanAgent(s.pool.QueryRow(ctx,
-		`INSERT INTO agents (name, api_key_hash, api_key_prefix, team, rate_limit, allowlist_mode)
-		 VALUES ($1, $2, $3, $4, $5, $6)
+		`INSERT INTO agents (name, api_key_hash, api_key_prefix, api_key_suffix, team, rate_limit, allowlist_mode)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
 		 RETURNING `+agentColumns,
-		in.Name, in.APIKeyHash, in.APIKeyPrefix, in.Team, in.RateLimit, false,
+		in.Name, in.APIKeyHash, in.APIKeyPrefix, in.APIKeySuffix, in.Team, in.RateLimit, false,
 	))
 	if err != nil {
 		return nil, fmt.Errorf("creating agent: %w", err)
@@ -231,16 +231,18 @@ func (s *Store) ListIDsByTeams(ctx context.Context, teams []string) ([]string, e
 
 // RotateKey moves the current key to prev_key with a 24h grace period and sets
 // the new key as the active key.
-func (s *Store) RotateKey(ctx context.Context, id, newHash, newPrefix string) (*Agent, error) {
+func (s *Store) RotateKey(ctx context.Context, id, newHash, newPrefix, newSuffix string) (*Agent, error) {
 	a, err := scanAgent(s.pool.QueryRow(ctx,
 		`UPDATE agents
 		 SET prev_key_hash = api_key_hash,
+		     prev_key_prefix = api_key_prefix,
 		     prev_key_expires_at = now() + interval '24 hours',
 		     api_key_hash = $1,
-		     api_key_prefix = $2
-		 WHERE id = $3 AND archived_at IS NULL
+		     api_key_prefix = $2,
+		     api_key_suffix = $3
+		 WHERE id = $4 AND archived_at IS NULL
 		 RETURNING `+agentColumns,
-		newHash, newPrefix, id,
+		newHash, newPrefix, newSuffix, id,
 	))
 	if err != nil {
 		return nil, fmt.Errorf("rotating agent key: %w", err)
@@ -253,6 +255,7 @@ func (s *Store) RevokePrevKey(ctx context.Context, id string) (*Agent, error) {
 	a, err := scanAgent(s.pool.QueryRow(ctx,
 		`UPDATE agents
 		 SET prev_key_hash = NULL,
+		     prev_key_prefix = NULL,
 		     prev_key_expires_at = NULL
 		 WHERE id = $1 AND archived_at IS NULL
 		 RETURNING `+agentColumns,
@@ -269,7 +272,7 @@ func (s *Store) RevokePrevKey(ctx context.Context, id string) (*Agent, error) {
 func (s *Store) CleanupExpiredKeys(ctx context.Context) (int64, error) {
 	tag, err := s.pool.Exec(ctx,
 		`UPDATE agents
-		 SET prev_key_hash = NULL, prev_key_expires_at = NULL
+		 SET prev_key_hash = NULL, prev_key_prefix = NULL, prev_key_expires_at = NULL
 		 WHERE prev_key_expires_at IS NOT NULL AND prev_key_expires_at <= now()`,
 	)
 	if err != nil {
@@ -280,8 +283,8 @@ func (s *Store) CleanupExpiredKeys(ctx context.Context) (int64, error) {
 
 // RegenerateKey updates the api_key_hash and api_key_prefix for the given agent.
 // Deprecated: Use RotateKey for zero-downtime rotation with a grace period.
-func (s *Store) RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*Agent, error) {
-	return s.RotateKey(ctx, id, newHash, newPrefix)
+func (s *Store) RegenerateKey(ctx context.Context, id, newHash, newPrefix, newSuffix string) (*Agent, error) {
+	return s.RotateKey(ctx, id, newHash, newPrefix, newSuffix)
 }
 
 // Update performs a partial update on the agent with the given id and returns

--- a/internal/api/agents_handler.go
+++ b/internal/api/agents_handler.go
@@ -19,7 +19,7 @@ type agentStore interface {
 	Update(ctx context.Context, id string, in agent.UpdateAgentInput) (*agent.Agent, error)
 	Archive(ctx context.Context, id string) error
 	List(ctx context.Context, params agent.AgentListParams) ([]*agent.Agent, string, error)
-	RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*agent.Agent, error)
+	RegenerateKey(ctx context.Context, id, newHash, newPrefix, newSuffix string) (*agent.Agent, error)
 	RevokePrevKey(ctx context.Context, id string) (*agent.Agent, error)
 }
 
@@ -74,6 +74,7 @@ func (h *agentsHandler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Name:         req.Name,
 		APIKeyHash:   apiKey.Hash,
 		APIKeyPrefix: apiKey.Prefix,
+		APIKeySuffix: apiKey.Suffix,
 		Team:         req.Team,
 		RateLimit:    req.RateLimit,
 	}
@@ -214,7 +215,7 @@ func (h *agentsHandler) RegenerateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ag, err := h.store.RegenerateKey(r.Context(), id, apiKey.Hash, apiKey.Prefix)
+	ag, err := h.store.RegenerateKey(r.Context(), id, apiKey.Hash, apiKey.Prefix, apiKey.Suffix)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "not_found", "agent not found")

--- a/internal/api/agents_handler.go
+++ b/internal/api/agents_handler.go
@@ -20,6 +20,7 @@ type agentStore interface {
 	Archive(ctx context.Context, id string) error
 	List(ctx context.Context, params agent.AgentListParams) ([]*agent.Agent, string, error)
 	RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*agent.Agent, error)
+	RevokePrevKey(ctx context.Context, id string) (*agent.Agent, error)
 }
 
 // agentBudgetStore defines the budget store methods used by the agents handler.
@@ -199,6 +200,7 @@ func (h *agentsHandler) GetSelfAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 // RegenerateKey handles POST /api/v1/admin/agents/{id}/regenerate-key (admin).
+// Rotates the key: the old key remains valid for 24 hours.
 func (h *agentsHandler) RegenerateKey(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if id == "" {
@@ -233,7 +235,34 @@ func (h *agentsHandler) RegenerateKey(w http.ResponseWriter, r *http.Request) {
 		"rate_limit":     ag.RateLimit,
 		"created_at":     ag.CreatedAt,
 	}
+	if ag.PrevKeyExpiresAt != nil {
+		resp["prev_key_expires_at"] = ag.PrevKeyExpiresAt
+	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// RevokeKey handles POST /api/v1/admin/agents/{id}/revoke-prev-key (admin).
+// Immediately revokes the previous (expiring) key.
+func (h *agentsHandler) RevokeKey(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_id", "agent id is required")
+		return
+	}
+
+	ag, err := h.store.RevokePrevKey(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not_found", "agent not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "failed to revoke key")
+		return
+	}
+
+	auditLog(r, "revoke_prev_key", "agent", id, "name", ag.Name)
+
+	writeJSON(w, http.StatusOK, ag)
 }
 
 // SetBudget handles PUT /api/v1/agents/{agentID}/budgets/{toolID} (admin).

--- a/internal/api/agents_handler_test.go
+++ b/internal/api/agents_handler_test.go
@@ -90,15 +90,18 @@ func (f *fakeAgentStore) List(_ context.Context, _ agent.AgentListParams) ([]*ag
 	return list, "", nil
 }
 
-func (f *fakeAgentStore) RegenerateKey(_ context.Context, id, newHash, newPrefix string) (*agent.Agent, error) {
+func (f *fakeAgentStore) RegenerateKey(_ context.Context, id, newHash, newPrefix, newSuffix string) (*agent.Agent, error) {
 	a, ok := f.agents[id]
 	if !ok {
 		return nil, pgx.ErrNoRows
 	}
 	oldHash := a.APIKeyHash
+	oldPrefix := a.APIKeyPrefix
 	a.APIKeyHash = newHash
 	a.APIKeyPrefix = newPrefix
+	a.APIKeySuffix = newSuffix
 	a.PrevKeyHash = &oldHash
+	a.PrevKeyPrefix = &oldPrefix
 	expires := time.Now().Add(24 * time.Hour)
 	a.PrevKeyExpiresAt = &expires
 	return a, nil

--- a/internal/api/agents_handler_test.go
+++ b/internal/api/agents_handler_test.go
@@ -95,8 +95,22 @@ func (f *fakeAgentStore) RegenerateKey(_ context.Context, id, newHash, newPrefix
 	if !ok {
 		return nil, pgx.ErrNoRows
 	}
+	oldHash := a.APIKeyHash
 	a.APIKeyHash = newHash
 	a.APIKeyPrefix = newPrefix
+	a.PrevKeyHash = &oldHash
+	expires := time.Now().Add(24 * time.Hour)
+	a.PrevKeyExpiresAt = &expires
+	return a, nil
+}
+
+func (f *fakeAgentStore) RevokePrevKey(_ context.Context, id string) (*agent.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return nil, pgx.ErrNoRows
+	}
+	a.PrevKeyHash = nil
+	a.PrevKeyExpiresAt = nil
 	return a, nil
 }
 
@@ -177,6 +191,7 @@ func setupAdminAgentsRouter(store *fakeAgentStore, budgetStore *fakeBudgetStore)
 	r.Put("/agents/{id}", h.UpdateAgent)
 	r.Delete("/agents/{id}", h.DeleteAgent)
 	r.Post("/agents/{id}/regenerate-key", h.RegenerateKey)
+	r.Post("/agents/{id}/revoke-prev-key", h.RevokeKey)
 	r.Put("/agents/{agentID}/budgets/{toolID}", h.SetBudget)
 	r.Get("/agents/{agentID}/budgets/{toolID}", h.GetBudget)
 	r.Get("/agents/{agentID}/budgets", h.ListBudgets)
@@ -797,5 +812,101 @@ func TestListBudgets_Empty(t *testing.T) {
 	}
 	if len(budgets) != 0 {
 		t.Errorf("expected 0 budgets, got %d", len(budgets))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Key rotation tests
+// ---------------------------------------------------------------------------
+
+func TestRegenerateKey_ReturnsPrevKeyExpiresAt(t *testing.T) {
+	store := newFakeAgentStore()
+	store.agents["a1"] = &agent.Agent{
+		ID:           "a1",
+		Name:         "test-agent",
+		APIKeyHash:   "oldhash",
+		APIKeyPrefix: "octroi_old123",
+		Team:         "eng",
+		RateLimit:    100,
+		CreatedAt:    time.Now().UTC(),
+	}
+
+	router := setupAdminAgentsRouter(store, newFakeBudgetStore())
+	req := httptest.NewRequest(http.MethodPost, "/agents/a1/regenerate-key", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Should have prev_key_expires_at in response.
+	if resp["prev_key_expires_at"] == nil {
+		t.Error("expected prev_key_expires_at to be present after key rotation")
+	}
+
+	// New key should be different from old prefix.
+	if resp["api_key_prefix"] == "octroi_old123" {
+		t.Error("expected api_key_prefix to change after rotation")
+	}
+
+	// The old key hash should be stored.
+	if store.agents["a1"].PrevKeyHash == nil {
+		t.Error("expected prev_key_hash to be set after rotation")
+	}
+	if *store.agents["a1"].PrevKeyHash != "oldhash" {
+		t.Errorf("expected prev_key_hash to be 'oldhash', got %q", *store.agents["a1"].PrevKeyHash)
+	}
+}
+
+func TestRevokeKey_Success(t *testing.T) {
+	store := newFakeAgentStore()
+	oldHash := "oldhash"
+	expires := time.Now().Add(24 * time.Hour)
+	store.agents["a1"] = &agent.Agent{
+		ID:               "a1",
+		Name:             "test-agent",
+		APIKeyHash:       "newhash",
+		APIKeyPrefix:     "octroi_new123",
+		Team:             "eng",
+		RateLimit:        100,
+		CreatedAt:        time.Now().UTC(),
+		PrevKeyHash:      &oldHash,
+		PrevKeyExpiresAt: &expires,
+	}
+
+	router := setupAdminAgentsRouter(store, newFakeBudgetStore())
+	req := httptest.NewRequest(http.MethodPost, "/agents/a1/revoke-prev-key", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify the previous key was cleared.
+	if store.agents["a1"].PrevKeyHash != nil {
+		t.Error("expected prev_key_hash to be nil after revoke")
+	}
+	if store.agents["a1"].PrevKeyExpiresAt != nil {
+		t.Error("expected prev_key_expires_at to be nil after revoke")
+	}
+}
+
+func TestRevokeKey_NotFound(t *testing.T) {
+	store := newFakeAgentStore()
+	router := setupAdminAgentsRouter(store, newFakeBudgetStore())
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/nonexistent/revoke-prev-key", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/api/member_handler.go
+++ b/internal/api/member_handler.go
@@ -23,6 +23,7 @@ type memberAgentStore interface {
 	Update(ctx context.Context, id string, in agent.UpdateAgentInput) (*agent.Agent, error)
 	Archive(ctx context.Context, id string) error
 	RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*agent.Agent, error)
+	RevokePrevKey(ctx context.Context, id string) (*agent.Agent, error)
 	ListIDsByTeams(ctx context.Context, teams []string) ([]string, error)
 }
 
@@ -310,7 +311,7 @@ func (h *memberHandler) RegenerateKey(w http.ResponseWriter, r *http.Request) {
 
 	auditLog(r, "regenerate_key", "agent", id, "name", ag.Name)
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"id":             ag.ID,
 		"name":           ag.Name,
 		"api_key_prefix": ag.APIKeyPrefix,
@@ -318,7 +319,51 @@ func (h *memberHandler) RegenerateKey(w http.ResponseWriter, r *http.Request) {
 		"team":           ag.Team,
 		"rate_limit":     ag.RateLimit,
 		"created_at":     ag.CreatedAt,
-	})
+	}
+	if ag.PrevKeyExpiresAt != nil {
+		resp["prev_key_expires_at"] = ag.PrevKeyExpiresAt
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// RevokeKey handles POST /api/v1/member/agents/{id}/revoke-prev-key.
+func (h *memberHandler) RevokeKey(w http.ResponseWriter, r *http.Request) {
+	u := auth.UserFromContext(r.Context())
+	if u == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "not authenticated")
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_id", "agent id is required")
+		return
+	}
+
+	// Verify ownership.
+	existing, err := h.agentStore.GetByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not_found", "agent not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", "failed to get agent")
+		return
+	}
+	if !u.InTeam(existing.Team) {
+		writeError(w, http.StatusNotFound, "not_found", "agent not found")
+		return
+	}
+
+	ag, err := h.agentStore.RevokePrevKey(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "failed to revoke key")
+		return
+	}
+
+	auditLog(r, "revoke_prev_key", "agent", id, "name", ag.Name)
+
+	writeJSON(w, http.StatusOK, ag)
 }
 
 // GetUsage handles GET /api/v1/member/usage — team-scoped usage.

--- a/internal/api/member_handler.go
+++ b/internal/api/member_handler.go
@@ -22,7 +22,7 @@ type memberAgentStore interface {
 	Create(ctx context.Context, in agent.CreateAgentInput) (*agent.Agent, error)
 	Update(ctx context.Context, id string, in agent.UpdateAgentInput) (*agent.Agent, error)
 	Archive(ctx context.Context, id string) error
-	RegenerateKey(ctx context.Context, id, newHash, newPrefix string) (*agent.Agent, error)
+	RegenerateKey(ctx context.Context, id, newHash, newPrefix, newSuffix string) (*agent.Agent, error)
 	RevokePrevKey(ctx context.Context, id string) (*agent.Agent, error)
 	ListIDsByTeams(ctx context.Context, teams []string) ([]string, error)
 }
@@ -157,6 +157,7 @@ func (h *memberHandler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Name:         req.Name,
 		APIKeyHash:   apiKey.Hash,
 		APIKeyPrefix: apiKey.Prefix,
+		APIKeySuffix: apiKey.Suffix,
 		Team:         team,
 		RateLimit:    req.RateLimit,
 	}
@@ -303,7 +304,7 @@ func (h *memberHandler) RegenerateKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ag, err := h.agentStore.RegenerateKey(r.Context(), id, apiKey.Hash, apiKey.Prefix)
+	ag, err := h.agentStore.RegenerateKey(r.Context(), id, apiKey.Hash, apiKey.Prefix, apiKey.Suffix)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "failed to regenerate key")
 		return

--- a/internal/api/member_handler_test.go
+++ b/internal/api/member_handler_test.go
@@ -100,8 +100,22 @@ func (f *fakeMemberAgentStore) RegenerateKey(_ context.Context, id, newHash, new
 	if !ok {
 		return nil, pgx.ErrNoRows
 	}
+	oldHash := a.APIKeyHash
 	a.APIKeyHash = newHash
 	a.APIKeyPrefix = newPrefix
+	a.PrevKeyHash = &oldHash
+	expires := time.Now().Add(24 * time.Hour)
+	a.PrevKeyExpiresAt = &expires
+	return a, nil
+}
+
+func (f *fakeMemberAgentStore) RevokePrevKey(_ context.Context, id string) (*agent.Agent, error) {
+	a, ok := f.agents[id]
+	if !ok {
+		return nil, pgx.ErrNoRows
+	}
+	a.PrevKeyHash = nil
+	a.PrevKeyExpiresAt = nil
 	return a, nil
 }
 

--- a/internal/api/member_handler_test.go
+++ b/internal/api/member_handler_test.go
@@ -95,15 +95,18 @@ func (f *fakeMemberAgentStore) Archive(_ context.Context, id string) error {
 	return nil
 }
 
-func (f *fakeMemberAgentStore) RegenerateKey(_ context.Context, id, newHash, newPrefix string) (*agent.Agent, error) {
+func (f *fakeMemberAgentStore) RegenerateKey(_ context.Context, id, newHash, newPrefix, newSuffix string) (*agent.Agent, error) {
 	a, ok := f.agents[id]
 	if !ok {
 		return nil, pgx.ErrNoRows
 	}
 	oldHash := a.APIKeyHash
+	oldPrefix := a.APIKeyPrefix
 	a.APIKeyHash = newHash
 	a.APIKeyPrefix = newPrefix
+	a.APIKeySuffix = newSuffix
 	a.PrevKeyHash = &oldHash
+	a.PrevKeyPrefix = &oldPrefix
 	expires := time.Now().Add(24 * time.Hour)
 	a.PrevKeyExpiresAt = &expires
 	return a, nil

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -266,6 +266,7 @@ func NewRouter(deps RouterDeps) http.Handler {
 		ar.Put("/agents/{id}", agents.UpdateAgent)
 		ar.Delete("/agents/{id}", agents.DeleteAgent)
 		ar.Post("/agents/{id}/regenerate-key", agents.RegenerateKey)
+		ar.Post("/agents/{id}/revoke-prev-key", agents.RevokeKey)
 
 		// Budget management.
 		ar.Put("/agents/{agentID}/budgets/{toolID}", agents.SetBudget)
@@ -352,6 +353,7 @@ func NewRouter(deps RouterDeps) http.Handler {
 			mr.Put("/agents/{id}", member.UpdateAgent)
 			mr.Delete("/agents/{id}", member.DeleteAgent)
 			mr.Post("/agents/{id}/regenerate-key", member.RegenerateKey)
+			mr.Post("/agents/{id}/revoke-prev-key", member.RevokeKey)
 			mr.Get("/usage", member.GetUsage)
 			mr.Get("/usage/transactions", member.ListTransactions)
 			mr.Get("/teams", teams.MemberListTeams)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,10 +17,11 @@ type Agent struct {
 	RateLimit int
 }
 
-// APIKey holds the hashed key and a short prefix for identification.
+// APIKey holds the hashed key and short prefix/suffix for identification.
 type APIKey struct {
 	Hash   string
 	Prefix string // first 14 characters of the plaintext key
+	Suffix string // last 4 characters of the plaintext key
 }
 
 // TeamMembership represents a user's membership in a team with a role.
@@ -112,6 +113,7 @@ func GenerateAPIKey() (APIKey, string, error) {
 	key := APIKey{
 		Hash:   HashKey(plaintext),
 		Prefix: plaintext[:14],
+		Suffix: plaintext[len(plaintext)-4:],
 	}
 
 	return key, plaintext, nil

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -1033,6 +1033,7 @@ body.shift-held .txn-filter-pending { background: var(--surface2); }
     </div>
     <div class="modal-actions">
       <button class="btn-warn" id="agent-regen-btn" onclick="regenKeyFromModal()" style="display:none;margin-right:auto">Regenerate Key</button>
+      <button class="btn-warn" id="agent-revoke-btn" onclick="revokeOldKeyFromModal()" style="display:none;margin-right:0;background:var(--danger,#dc3545);border-color:var(--danger,#dc3545)">Revoke Old Key</button>
       <button class="btn-ghost" onclick="closeModal('agent-modal')">Cancel</button>
       <button class="btn-primary" id="agent-submit-btn" onclick="submitAgent()">Create</button>
     </div>
@@ -2015,10 +2016,28 @@ function openAgentModal(ag) {
   const keyGroup = document.getElementById('agent-key-group');
   const keyDisplay = document.getElementById('agent-key-display');
   if (ag && ag.api_key_prefix) {
-    keyDisplay.textContent = ag.api_key_prefix + '...';
+    let keyText = ag.api_key_prefix + '...';
+    if (ag.prev_key_expires_at) {
+      const expires = new Date(ag.prev_key_expires_at);
+      const now = new Date();
+      if (expires > now) {
+        const hoursLeft = Math.max(0, Math.round((expires - now) / 3600000));
+        const minsLeft = Math.max(0, Math.round((expires - now) / 60000));
+        const timeLeft = hoursLeft > 0 ? hoursLeft + 'h' : minsLeft + 'm';
+        keyText += '  (old key expiring in ' + timeLeft + ')';
+      }
+    }
+    keyDisplay.textContent = keyText;
     keyGroup.style.display = '';
   } else {
     keyGroup.style.display = 'none';
+  }
+  // Show/hide revoke button based on whether there is an expiring previous key.
+  const revokeBtn = document.getElementById('agent-revoke-btn');
+  if (ag && ag.prev_key_expires_at && new Date(ag.prev_key_expires_at) > new Date()) {
+    revokeBtn.style.display = '';
+  } else {
+    revokeBtn.style.display = 'none';
   }
   // Allowlist mode + permissions (edit mode only)
   const allowlistSection = document.getElementById('agent-allowlist-section');
@@ -2140,13 +2159,26 @@ async function regenKeyFromModal() {
   const id = document.getElementById('agent-edit-id').value;
   const name = document.getElementById('agent-name').value;
   if (!id) return;
-  if (!await appConfirm('Regenerate API key for "' + name + '"? The old key will stop working immediately.', { title: 'Regenerate Key', okLabel: 'Regenerate' })) return;
+  if (!await appConfirm('Regenerate API key for "' + name + '"? The old key will continue working for 24 hours.', { title: 'Regenerate Key', okLabel: 'Regenerate' })) return;
   try {
     const res = await api('POST', apiBase() + '/agents/' + id + '/regenerate-key');
     if (res.api_key) {
       document.getElementById('agent-key-value').textContent = res.api_key;
       document.getElementById('agent-key-banner').classList.add('show');
     }
+    closeModal('agent-modal');
+    loadAgents();
+  } catch (e) { toast('Error: ' + e.message); }
+}
+
+async function revokeOldKeyFromModal() {
+  const id = document.getElementById('agent-edit-id').value;
+  const name = document.getElementById('agent-name').value;
+  if (!id) return;
+  if (!await appConfirm('Immediately revoke the old key for "' + name + '"? It will stop working right away.', { title: 'Revoke Old Key', okLabel: 'Revoke' })) return;
+  try {
+    await api('POST', apiBase() + '/agents/' + id + '/revoke-prev-key');
+    toast('Old key revoked');
     closeModal('agent-modal');
     loadAgents();
   } catch (e) { toast('Error: ' + e.message); }

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -988,8 +988,8 @@ body.shift-held .txn-filter-pending { background: var(--surface2); }
       <code id="agent-id-display" style="display:block;padding:6px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:12px;color:var(--text2);user-select:all"></code>
     </div>
     <div class="form-group" id="agent-key-group" style="display:none">
-      <label>Key</label>
-      <div class="mono" id="agent-key-display" style="padding:4px 0;color:var(--text2)"></div>
+      <label>Keys</label>
+      <div id="agent-key-display" style="padding:4px 0;font-size:12px"></div>
     </div>
     <div class="form-group">
       <label>Name *</label>
@@ -1997,33 +1997,34 @@ function openAgentModal(ag) {
   teamSel.value = ag ? ag.team || '' : '';
   document.getElementById('agent-rate-limit').value = ag ? ag.rate_limit || '' : '';
   document.getElementById('agent-regen-btn').style.display = ag ? '' : 'none';
-  // Show key prefix in edit mode
+  // Show key info in edit mode
   const keyGroup = document.getElementById('agent-key-group');
   const keyDisplay = document.getElementById('agent-key-display');
+  const hasPrevKey = ag && ag.prev_key_expires_at && ag.prev_key_prefix && new Date(ag.prev_key_expires_at) > new Date();
   if (ag && ag.api_key_prefix) {
-    let keyText = ag.api_key_prefix + '...';
-    if (ag.prev_key_expires_at) {
+    const mask = (prefix, suffix) => prefix + '…' + (suffix || '');
+    let html = '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px">'
+      + '<code style="font-size:12px;color:var(--text)">' + esc(mask(ag.api_key_prefix, ag.api_key_suffix)) + '</code>'
+      + '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--green,#22c55e);color:#fff">active</span>'
+      + '</div>';
+    if (hasPrevKey) {
       const expires = new Date(ag.prev_key_expires_at);
-      const now = new Date();
-      if (expires > now) {
-        const hoursLeft = Math.max(0, Math.round((expires - now) / 3600000));
-        const minsLeft = Math.max(0, Math.round((expires - now) / 60000));
-        const timeLeft = hoursLeft > 0 ? hoursLeft + 'h' : minsLeft + 'm';
-        keyText += '  (old key expiring in ' + timeLeft + ')';
-      }
+      const hoursLeft = Math.max(0, Math.round((expires - new Date()) / 3600000));
+      const minsLeft = Math.max(0, Math.round((expires - new Date()) / 60000));
+      const timeLeft = hoursLeft > 0 ? hoursLeft + 'h' : minsLeft + 'm';
+      html += '<div style="display:flex;align-items:center;gap:6px">'
+        + '<code style="font-size:12px;color:var(--text2)">' + esc(mask(ag.prev_key_prefix, '')) + '</code>'
+        + '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--warning,#f59e0b);color:#fff">expiring in ' + timeLeft + '</span>'
+        + '</div>';
     }
-    keyDisplay.textContent = keyText;
+    keyDisplay.innerHTML = html;
     keyGroup.style.display = '';
   } else {
     keyGroup.style.display = 'none';
   }
   // Show/hide revoke button based on whether there is an expiring previous key.
   const revokeBtn = document.getElementById('agent-revoke-btn');
-  if (ag && ag.prev_key_expires_at && new Date(ag.prev_key_expires_at) > new Date()) {
-    revokeBtn.style.display = '';
-  } else {
-    revokeBtn.style.display = 'none';
-  }
+  revokeBtn.style.display = hasPrevKey ? '' : 'none';
   // Allowlist mode + permissions (edit mode only)
   const allowlistSection = document.getElementById('agent-allowlist-section');
   const permsSection = document.getElementById('agent-permissions-section');

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -222,18 +222,6 @@ tbody tr:hover { background: var(--surface); }
   opacity: 0; transition: opacity 0.2s;
 }
 .toast.show { opacity: 1; }
-/* Banner */
-.banner {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--success);
-  padding: 8px 12px;
-  margin-bottom: 12px;
-  font-size: 12px;
-  display: none;
-}
-.banner.show { display: block; }
-.banner .key-value { font-weight: 700; color: var(--text); user-select: all; }
 /* Select (global) */
 select {
   appearance: none;
@@ -561,9 +549,6 @@ body.shift-held .txn-filter-pending { background: var(--surface2); }
 <div class="content" id="main-content" style="display:none">
   <!-- Agents Tab -->
   <div class="tab-panel active" id="tab-agents">
-    <div class="banner" id="agent-key-banner">
-      API key (shown once, copy now): <span class="key-value" id="agent-key-value"></span>
-    </div>
     <div style="display:flex;align-items:center;margin-bottom:8px;gap:8px">
       <h2 class="toolbar-title">Agents</h2>
       <input type="text" class="tab-search" id="agents-search" placeholder="Search agents..." oninput="renderAgents()">
@@ -2147,8 +2132,7 @@ async function submitAgent() {
       const res = await api('POST', apiBase() + '/agents', body);
       closeModal('agent-modal');
       if (res.api_key) {
-        document.getElementById('agent-key-value').textContent = res.api_key;
-        document.getElementById('agent-key-banner').classList.add('show');
+        await showNewKeyModal(res.api_key);
       }
     }
     loadAgents();
@@ -2162,11 +2146,10 @@ async function regenKeyFromModal() {
   if (!await appConfirm('Regenerate API key for "' + name + '"? The old key will continue working for 24 hours.', { title: 'Regenerate Key', okLabel: 'Regenerate' })) return;
   try {
     const res = await api('POST', apiBase() + '/agents/' + id + '/regenerate-key');
-    if (res.api_key) {
-      document.getElementById('agent-key-value').textContent = res.api_key;
-      document.getElementById('agent-key-banner').classList.add('show');
-    }
     closeModal('agent-modal');
+    if (res.api_key) {
+      await showNewKeyModal(res.api_key);
+    }
     loadAgents();
   } catch (e) { toast('Error: ' + e.message); }
 }
@@ -2182,6 +2165,15 @@ async function revokeOldKeyFromModal() {
     closeModal('agent-modal');
     loadAgents();
   } catch (e) { toast('Error: ' + e.message); }
+}
+
+function showNewKeyModal(apiKey) {
+  return appAlert(
+    '<p style="margin:0 0 8px">This key will only be shown once. Copy it now.</p>' +
+    '<code style="display:block;padding:10px;background:var(--surface);border-radius:4px;word-break:break-all;user-select:all;font-size:13px;cursor:pointer" onclick="navigator.clipboard.writeText(this.textContent).then(()=>document.getElementById(\'key-copied-msg\').style.display=\'block\')">' + esc(apiKey) + '</code>' +
+    '<p id="key-copied-msg" style="display:none;color:var(--green,#22c55e);font-size:11px;margin:6px 0 0">Copied to clipboard</p>',
+    { title: 'New API Key' }
+  );
 }
 
 async function deleteAgent(id, name) {

--- a/migrations/000003_key_rotation.down.sql
+++ b/migrations/000003_key_rotation.down.sql
@@ -1,3 +1,5 @@
 ALTER TABLE agents
     DROP COLUMN prev_key_hash,
-    DROP COLUMN prev_key_expires_at;
+    DROP COLUMN prev_key_expires_at,
+    DROP COLUMN api_key_suffix,
+    DROP COLUMN prev_key_prefix;

--- a/migrations/000003_key_rotation.down.sql
+++ b/migrations/000003_key_rotation.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agents
+    DROP COLUMN prev_key_hash,
+    DROP COLUMN prev_key_expires_at;

--- a/migrations/000003_key_rotation.up.sql
+++ b/migrations/000003_key_rotation.up.sql
@@ -1,3 +1,5 @@
 ALTER TABLE agents
     ADD COLUMN prev_key_hash TEXT,
-    ADD COLUMN prev_key_expires_at TIMESTAMPTZ;
+    ADD COLUMN prev_key_expires_at TIMESTAMPTZ,
+    ADD COLUMN api_key_suffix TEXT NOT NULL DEFAULT '',
+    ADD COLUMN prev_key_prefix TEXT;

--- a/migrations/000003_key_rotation.up.sql
+++ b/migrations/000003_key_rotation.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agents
+    ADD COLUMN prev_key_hash TEXT,
+    ADD COLUMN prev_key_expires_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary
- Support two active keys per agent for zero-downtime key rotation
- "Regenerate" creates a new key and marks the old one as expiring (24h grace period)
- Key state machine: active → expiring → revoked
- Immediate revoke option available for compromised keys
- Auth middleware checks both active and expiring keys
- UI shows key status and expiry countdown

Closes #3

## Test plan
- [ ] Regenerate key → old key still works for 24h
- [ ] After 24h, old key stops working
- [ ] Immediate revoke stops old key instantly
- [ ] New key works immediately after rotation
- [ ] UI shows expiring key status and countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)